### PR TITLE
feat(commands): New workspace details command

### DIFF
--- a/extension-client/src/api/index.ts
+++ b/extension-client/src/api/index.ts
@@ -65,7 +65,11 @@ export async function uploadTar(payload: any): Promise<any> {
     });
 }
 
-export async function getWorkspace(id: string, credentials: any) {
+export async function getWorkspace(id: string, credentials: any = undefined) {
+    if (!credentials) {
+        credentials = await util.workspace.readCredentials();
+    }
+
     const authenticator = auth.getAuthenticator(credentials);
 
     const schematicsService = new schematicsV1({

--- a/extension-client/src/command/workspace/index.ts
+++ b/extension-client/src/command/workspace/index.ts
@@ -25,6 +25,8 @@ export * from './log';
 export * from './job';
 export * from './variables';
 
+import DetailsView from '../../webview/workspace/DetailsView';
+
 const fs = require('fs');
 
 export async function create(): Promise<void> {
@@ -120,6 +122,25 @@ export async function deleteWorkspace(): Promise<void> {
             .catch((error) => {
                 console.log(error);
             });
+    } catch (error) {
+        console.log(error);
+        vscode.window.showErrorMessage(String(error));
+    }
+}
+
+export async function read(context: vscode.ExtensionContext): Promise<void> {
+    const isDeployed = util.workspace.isDeployed();
+    if (!isDeployed) {
+        vscode.window.showErrorMessage(
+            'Workspace not deployed. Make sure you have deployed your workspace.'
+        );
+        return;
+    }
+
+    try {
+        const ws = await util.workspace.readSchematicsWorkspace();
+        const view = new DetailsView(context, ws.id);
+        view.openView(true);
     } catch (error) {
         console.log(error);
         vscode.window.showErrorMessage(String(error));

--- a/extension-client/src/extension.ts
+++ b/extension-client/src/extension.ts
@@ -108,6 +108,12 @@ export function activate(context: vscode.ExtensionContext) {
         (data) => command.workspace.saveVariables(context, data)
     );
     context.subscriptions.push(saveVariablesCmd);
+
+    var wsDetailsCmd = vscode.commands.registerCommand(
+        'schematics.workspace.details',
+        () => command.workspace.read(context)
+    );
+    context.subscriptions.push(wsDetailsCmd);
 }
 
 // This method is called when your extension is deactivated

--- a/extension-client/src/webview/workspace/DetailsView.ts
+++ b/extension-client/src/webview/workspace/DetailsView.ts
@@ -1,0 +1,52 @@
+/**
+ * IBM Cloud Schematics
+ * (C) Copyright IBM Corp. 2021 All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as vscode from 'vscode';
+import * as api from '../../api';
+import { ReactView } from '../ReactView';
+
+export default class DetailView extends ReactView {
+    static viewID: string = 'workspace.detail';
+    static viewTitle: string = 'Workspace Detail';
+    private _jobID: string;
+
+    constructor(context: vscode.ExtensionContext, jobID: string) {
+        super(context, DetailView.viewID, DetailView.viewTitle);
+        this._jobID = jobID;
+    }
+
+    async openPanelInner(panel: vscode.WebviewPanel): Promise<void> {
+        await this.loadComponent(panel);
+    }
+
+    async loadComponent(panel: vscode.WebviewPanel): Promise<void> {
+        api.getWorkspace(this._jobID)
+            .then((result) => {
+                panel.webview.postMessage({
+                    path: '/workspace/details',
+                    message: result,
+                });
+            })
+            .catch((error) => {
+                console.log(error);
+                panel.webview.postMessage({
+                    path: '/error',
+                    message: String(error),
+                });
+            });
+    }
+}

--- a/extension-ui/package.json
+++ b/extension-ui/package.json
@@ -9,7 +9,6 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
-    "carbon-addons-iot-react": "^2.145.0",
     "carbon-components": "^10.39.0",
     "carbon-components-react": "^7.39.0",
     "carbon-icons": "^7.0.7",

--- a/extension-ui/public/index.html
+++ b/extension-ui/public/index.html
@@ -9,7 +9,7 @@
   <title>Extension UI</title>
 </head>
 
-<body>
+<body class="vscode-light">
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <main class="bx--content">
     <div id="root"></div>

--- a/extension-ui/src/App.js
+++ b/extension-ui/src/App.js
@@ -19,6 +19,7 @@ import React, { useState, useEffect } from 'react';
 import { HashRouter as Router, Route, Redirect } from 'react-router-dom';
 import Loader from './components/common/loader/Loader';
 import Jobs from './components/workspace/jobs';
+import WorkspaceDetail from './components/workspace/detail';
 import Log from './components/common/log/Log';
 import Resources from './components/workspace/resources';
 import Failure from './components/common/failure';
@@ -41,6 +42,11 @@ function App() {
         <Router>
             <Redirect to={redirectPath} />
             <Route exact path="/loading" render={() => <Loader />} />
+            <Route
+                exact
+                path="/workspace/details"
+                render={() => <WorkspaceDetail result={result} />}
+            />
             <Route
                 exact
                 path="/workspace/jobs"

--- a/extension-ui/src/components/workspace/_workspace.scss
+++ b/extension-ui/src/components/workspace/_workspace.scss
@@ -1,2 +1,3 @@
+@import './detail/detail';
 @import './jobs/jobs';
 @import './variables/variables';

--- a/extension-ui/src/components/workspace/detail/_detail.scss
+++ b/extension-ui/src/components/workspace/detail/_detail.scss
@@ -1,0 +1,10 @@
+.bx--workspace_detail {
+    h3 {
+        @include type-style(productive-heading-03);
+        margin-bottom: $spacing-05;
+    }
+
+    .bx--row {
+        margin-bottom: $spacing-07;
+    }
+}

--- a/extension-ui/src/components/workspace/detail/index.js
+++ b/extension-ui/src/components/workspace/detail/index.js
@@ -1,0 +1,68 @@
+import Moment from 'react-moment';
+import { Row, Column, CodeSnippet } from 'carbon-components-react';
+
+const mockData = require('./mock.json');
+
+const WorkspaceDetail = ({ result }) => {
+    result = result ? result : mockData;
+
+    return (
+        <div className="bx--workspace_detail">
+            <h3>Details</h3>
+            <div>
+                <Row>
+                    <Column lg={3}>
+                        <span className="bx--col_title">Name</span>
+                        <span className="bx--col_info">{result.name}</span>
+                    </Column>
+                    <Column lg={3}>
+                        <span className="bx--col_title">Workspace ID</span>
+                        <span className="bx--col_info">
+                            <CodeSnippet type="single">{result.id}</CodeSnippet>
+                        </span>
+                    </Column>
+                    <Column lg={3}>
+                        <span className="bx--col_title">State</span>
+                        <span className="bx--col_info">
+                            {result.workspace_status.frozen
+                                ? 'Frozen'
+                                : 'Unfrozen'}
+                        </span>
+                    </Column>
+                    <Column lg={3}>
+                        <span className="bx--col_title">Version</span>
+                        <span className="bx--col_info">{result.type[0]}</span>
+                    </Column>
+                </Row>
+                <Row>
+                    <Column lg={3}>
+                        <span className="bx--col_title">Location</span>
+                        <span className="bx--col_info">{result.location}</span>
+                    </Column>
+                    <Column lg={3}>
+                        <span className="bx--col_title">Resource group</span>
+                        <span className="bx--col_info">
+                            {result.resource_group}
+                        </span>
+                    </Column>
+                    <Column lg={3}>
+                        <span className="bx--col_title">Created by</span>
+                        <span className="bx--col_info">
+                            {result.created_by}
+                        </span>
+                    </Column>
+                    <Column lg={3}>
+                        <span className="bx--col_title">Date created</span>
+                        <span className="bx--col_info">
+                            <Moment format="YYYY/MM/DD, hh:mm A">
+                                {result.created_at}
+                            </Moment>
+                        </span>
+                    </Column>
+                </Row>
+            </div>
+        </div>
+    );
+};
+
+export default WorkspaceDetail;

--- a/extension-ui/src/components/workspace/detail/mock.json
+++ b/extension-ui/src/components/workspace/detail/mock.json
@@ -1,0 +1,70 @@
+{
+    "id": "us-east.workspace.myworkspace.2ee50965",
+    "name": "myworkspace",
+    "crn": "crn:v1:staging:public:schematics:us-south:a/0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0:00000000-0000-0000-0000-00000000000:workspace:us-east.workspace.myworkspace.2ee50965",
+    "type": [
+        "terraform_v0.12"
+    ],
+    "description": "",
+    "resource_group": "e749e7559337403ba044107520156333",
+    "location": "us-east",
+    "tags": [],
+    "created_at": "2021-08-11T21:47:30.128736+05:30",
+    "created_by": "test@mail.com",
+    "status": "INACTIVE",
+    "failure_reason": "",
+    "workspace_status_msg": {
+        "status_code": "200",
+        "status_msg": ""
+    },
+    "workspace_status": {
+        "frozen": false,
+        "locked": false
+    },
+    "template_repo": {
+        "url": "https://github.com/ptaube/tf_cloudless_sleepy",
+        "commit_id": "c0a1dbc6e7afe4dad06de617a7fc35e22ddd4f95",
+        "full_url": "https://github.com/ptaube/tf_cloudless_sleepy",
+        "has_uploadedgitrepotar": false
+    },
+    "template_data": [
+        {
+            "id": "de64f791-06bd-45",
+            "folder": ".",
+            "type": "terraform_v0.12",
+            "values_url": "https://localhost:8080/v1/workspaces/us-east.workspace.myworkspace.2ee50965/template_data/de64f791-06bd-45/values",
+            "values": "",
+            "values_metadata": [
+                {
+                    "default": "hello",
+                    "description": "A sample_var to pass to the template.",
+                    "name": "sample_var",
+                    "type": "string"
+                },
+                {
+                    "default": "0",
+                    "description": "How long our local-exec will take a nap.",
+                    "name": "sleepy_time",
+                    "type": "string"
+                }
+            ],
+            "has_githubtoken": false
+        }
+    ],
+    "runtime_data": [
+        {
+            "id": "de64f791-06bd-45",
+            "engine_name": "terraform",
+            "engine_version": "v0.12.31",
+            "state_store_url": "https://localhost:8080/v1/workspaces/us-east.workspace.myworkspace.2ee50965/runtime_data/de64f791-06bd-45/state_store",
+            "log_store_url": "https://localhost:8080/v1/workspaces/us-east.workspace.myworkspace.2ee50965/runtime_data/de64f791-06bd-45/log_store"
+        }
+    ],
+    "shared_data": {
+        "resource_group_id": ""
+    },
+    "applied_shareddata_ids": null,
+    "updated_at": "0001-01-01T00:00:00Z",
+    "last_health_check_at": "0001-01-01T00:00:00Z",
+    "cart_id": ""
+}

--- a/extension-ui/src/components/workspace/variables/_variables.scss
+++ b/extension-ui/src/components/workspace/variables/_variables.scss
@@ -9,7 +9,6 @@
 
     .bx--variables-wrapper {
         margin-top: $spacing-05;
-        
 
         .bx--variables-header {
             margin: 0;

--- a/extension-ui/src/style/_common.scss
+++ b/extension-ui/src/style/_common.scss
@@ -40,4 +40,34 @@
             color: $text-01;
         }
     }
+
+    .bx--copy {
+        font-size: 0;
+    }
+    
+    .bx--copy-btn {
+        display: flex;
+        width: 2.5rem;
+        height: 2.5rem;
+        align-items: center;
+        justify-content: center;
+        padding: 0;
+        border: none;
+        cursor: pointer;
+        background-color: $ui-01;
+    
+        &:hover {
+            background-color: $hover-ui;
+        }
+    }
+
+    .bx--col_title {
+        display: block;
+        @include carbon--type-style('helper-text-01');
+    }
+
+    .bx--col_info {
+        display: block;
+        @include carbon--type-style('body-short-01');
+    }
 }

--- a/extension-ui/src/style/app.scss
+++ b/extension-ui/src/style/app.scss
@@ -24,6 +24,7 @@ html {
             @import "carbon-components/scss/components/structured-list/_structured-list";
             @import "carbon-components/scss/components/text-area/_text-area";
             @import "carbon-components/scss/components/text-input/_text-input";
+            @import "carbon-components/scss/components/toggle/toggle";
 
             @import "./flex";
             @import "./common";
@@ -47,6 +48,7 @@ html {
             @import "carbon-components/scss/components/structured-list/_structured-list";
             @import "carbon-components/scss/components/text-area/_text-area";
             @import "carbon-components/scss/components/text-input/_text-input";
+            @import "carbon-components/scss/components/toggle/toggle";
 
             @import "./light";
             @import "./flex";

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
         "onCommand:schematics.workspace.apply",
         "onCommand:schematics.workspace.delete",
         "onCommand:schematics.workspace.destroyResources",
-        "onCommand:schematics.workspace.variables"
+        "onCommand:schematics.workspace.variables",
+        "onCommand:schematics.workspace.details"
     ],
     "main": "./dist/extension.js",
     "contributes": {
@@ -92,6 +93,11 @@
             {
                 "command": "schematics.workspace.variables",
                 "title": "View Variables",
+                "category": "IBM Cloud Schematics workspace"
+            },
+            {
+                "command": "schematics.workspace.details",
+                "title": "Details",
                 "category": "IBM Cloud Schematics workspace"
             }
         ],


### PR DESCRIPTION
Add new `schematics.workspace.details` command which will show the details of the deployed workspace

<img width="1630" alt="Screenshot 2021-08-16 at 11 47 17 PM" src="https://user-images.githubusercontent.com/1298628/129612219-2225871e-2d49-41db-81d0-91f8e5753690.png">
