### PR TITLE
cost estimation webview when no resource created

### DIFF
--- a/extension-ui/src/components/workspace/cost-estimation/index.js
+++ b/extension-ui/src/components/workspace/cost-estimation/index.js
@@ -30,6 +30,13 @@ const EstimateCost = ({ result }) => {
     return (
         <div className="bx--cost_detail">
             <h2>Cost Estimate</h2>
+            {!result.Lineitem || (Array.isArray(result.Lineitem) && result.Lineitem.length === 0)
+            ?
+            <div>
+                <p>There are no resources generated </p>
+                <p>Total estimated cost: 0 </p>
+            </div>
+            :
             <div>
                 <StructuredListWrapper>
                     <StructuredListHead>
@@ -106,8 +113,9 @@ const EstimateCost = ({ result }) => {
                     ratecard
                 </p>
             </div>
+        }
+               
         </div>
-    );
-};
+    );}
 
 export default EstimateCost;


### PR DESCRIPTION
<!---
Thank you for your contribution 🎉

Please make sure your PR's title follows the `conventional commit` guidelines.
<type>[optional scope]: <description>

types: `feat`, `fix`, `chore`, `refactor`
scopes: `task`, `command`, `ui`, `doc update`
-->

#### Relates to: Cost Estimation
<!---
- Issue number #10 [optional if no issue number]
-->

#### This pull request has following changes:
- webview in case no resources were generated
<!---
- Example: 
    - Added new command
    - Refactored code 
-->

#### Additional information, screenshots:
<!---
- Info
-->
<img width="496" alt="Screenshot 2022-04-18 at 1 29 56 PM" src="https://user-images.githubusercontent.com/77984471/163776924-fc2eaadd-71b0-4311-9951-71a74752d0a2.png">


